### PR TITLE
dotenv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem "bootsnap", require: false
 # tailwind
 gem "tailwindcss-rails"
 
+gem "dotenv-rails"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,10 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.4)
+    dotenv-rails (3.1.4)
+      dotenv (= 3.1.4)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -289,6 +293,7 @@ DEPENDENCIES
   brakeman
   capybara
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   pg (~> 1.5)


### PR DESCRIPTION
#48

- [x] should be ☁️  db

---

🔥

rails on  dotenv [$!+] via  v22.5.1 via 💎 v3.2.1 
❯ rails c
Loading development environment (Rails 7.2.1)
3.2.1 :001 > ActiveRecord::Base.connection.current_database
 => "railway" 
3.2.1 :002 > 
^C
3.2.1 :002 > 

---

notes

View all changes (both staged and unstaged):

```bash
git diff HEAD
```